### PR TITLE
image to events function added

### DIFF
--- a/rixs/plotting_functions.py
+++ b/rixs/plotting_functions.py
@@ -83,9 +83,7 @@ def plot_pcolor(ax, photon_events, cax=None, bins=None, **kwargs):
     kwargs.update({key: val for key, val in defaults.items()
                    if key not in kwargs})
 
-    xlim = (x_edges.min(), x_edges.max())
-    ylim = (y_edges.min(), y_edges.max())
-    image_artist = ax.pcolorfast(xlim, ylim, image, **kwargs)
+    image_artist = ax.pcolorfast(x_edges, y_edges, image, **kwargs)
     cb_artist = plt.colorbar(image_artist, ax=ax, cax=cax)
     ax.axis('tight')
 

--- a/rixs/process2d.py
+++ b/rixs/process2d.py
@@ -188,7 +188,7 @@ def apply_curvature(photon_events, curvature, bins=None):
                          corrected_y.max()//1 - 0.5)
     Ibin, y_edges = np.histogram(corrected_y, bins=bins, weights=Iph)
     y_centers = (y_edges[:-1] + y_edges[1:])/2
-    spectrum = np.vstack((y_centers, Ibin)).transpose()
+    spectrum = np.column_stack((y_centers, Ibin))
     return spectrum
 
 
@@ -270,8 +270,8 @@ def image_to_photon_events(image):
 
     choose = image > 0
 
-    photon_events = np.vstack((X_CENTERS[choose].ravel(),
-                               Y_CENTERS[choose].ravel(),
-                               image[choose].ravel())).T
+    photon_events = np.column_stack((X_CENTERS[choose].ravel(),
+                                     Y_CENTERS[choose].ravel(),
+                                     image[choose].ravel()))
 
     return photon_events

--- a/rixs/process2d.py
+++ b/rixs/process2d.py
@@ -194,7 +194,9 @@ def apply_curvature(photon_events, curvature, bins=None):
 
 def photon_events_to_image(photon_events, bins=None):
     """ Convert 1D photon events into 2D image
-    Opposite of image_to_photon_events
+    In the default binning, data at the edges is excluded, so that
+    problems with half empty bins are avoided. This might come at
+    the cost of loosing half a pixel of data.
 
     Parameters
     -----------
@@ -217,6 +219,7 @@ def photon_events_to_image(photon_events, bins=None):
         1D vector describing column position
     y_centers : array
         1D vector describing row position
+        +ve y is up convetion is applied.
     image : array
         2D image
     x_centers : array
@@ -236,5 +239,11 @@ def photon_events_to_image(photon_events, bins=None):
     image, y_edges, x_edges = np.histogram2d(y, x, bins=bins, weights=Iph)
     y_centers = (y_edges[:-1] + y_edges[1:])/2
     x_centers = (x_edges[:-1] + x_edges[1:])/2
+
+    # impose +ve y is up convention
+    yorder = np.argsort(y_centers)[::-1]
+    y_centers = y_centers[yorder]
+    image = image[yorder, :]
+    y_edges = y_edges[::-1]
 
     return x_centers, y_centers, image, x_edges, y_edges

--- a/rixs/process2d.py
+++ b/rixs/process2d.py
@@ -219,7 +219,7 @@ def photon_events_to_image(photon_events, bins=None):
         1D vector describing column position
     y_centers : array
         1D vector describing row position
-        +ve y is up convetion is applied.
+        +ve y is up convention is applied.
     image : array
         2D image
     x_centers : array

--- a/rixs/process2d.py
+++ b/rixs/process2d.py
@@ -247,3 +247,31 @@ def photon_events_to_image(photon_events, bins=None):
     y_edges = y_edges[::-1]
 
     return x_centers, y_centers, image, x_edges, y_edges
+
+
+def image_to_photon_events(image):
+    """ Convert 2D image into 1D photon events
+    This assumes integers define the centers of bins.
+    Zeros are not included.
+
+    Parameters
+    -----------
+    image : 2D np.array
+        photon intensities
+
+    Returns
+    -----------
+    photon_events : np.array
+        three column x, y, Iph photon locations and intensities
+    """
+    x_centers = np.arange(image.shape[1])
+    y_centers = np.arange(image.shape[0])[::-1]  # +ve y is up convention
+    X_CENTERS, Y_CENTERS = np.meshgrid(x_centers, y_centers)
+
+    choose = image > 0
+
+    photon_events = np.vstack((X_CENTERS[choose].ravel(),
+                               Y_CENTERS[choose].ravel(),
+                               image[choose].ravel())).T
+
+    return photon_events

--- a/rixs/tests/test_process2d.py
+++ b/rixs/tests/test_process2d.py
@@ -68,7 +68,8 @@ def test_apply_curvature():
 
 def test_photon_events_to_image():
     """Test conversion to image"""
-    x = np.arange(0, 10)
+    size = 10
+    x = np.arange(0, size)
     y = np.copy(x)
     Iph = np.ones_like(x)
 
@@ -81,6 +82,17 @@ def test_photon_events_to_image():
     assert_array_almost_equal(x[1:-1], x_centers)
     assert_array_almost_equal(y[1:-1][::-1], y_centers)
     assert_array_almost_equal(image, corresponding_image)
+
+
+def test_image_to_photon_events():
+    """Test conversion between image and photon_events"""
+    size = 10
+    image = np.identity(10)[::-1, :]
+
+    photon_events = process2d.image_to_photon_events(image)
+    assert_array_almost_equal(photon_events[:, 0], np.arange(size)[::-1])
+    assert_array_almost_equal(photon_events[:, 1], np.arange(size)[::-1])
+    assert_array_almost_equal(photon_events[:, 2], np.ones(size))
 
 
 def test_estimate_elastic_pos():

--- a/rixs/tests/test_process2d.py
+++ b/rixs/tests/test_process2d.py
@@ -71,14 +71,16 @@ def test_photon_events_to_image():
     x = np.arange(0, 10)
     y = np.copy(x)
     Iph = np.ones_like(x)
+
     photon_events = np.vstack((x, y, Iph)).T
     image_info = process2d.photon_events_to_image(photon_events)
     x_centers, y_centers, image, *_ = image_info
 
+    corresponding_image = np.identity(image.shape[0])[::-1, :]
+
     assert_array_almost_equal(x[1:-1], x_centers)
-    assert_array_almost_equal(y[1:-1], y_centers)
-    assert_array_almost_equal(x[1:-1], x_centers)
-    assert_array_almost_equal(image, np.identity(image.shape[0]))
+    assert_array_almost_equal(y[1:-1][::-1], y_centers)
+    assert_array_almost_equal(image, corresponding_image)
 
 
 def test_estimate_elastic_pos():


### PR DESCRIPTION
A function converting 2D data arrays (images) to three column events function was added.

y values are now returned high to low to impose the convention that +ve y is run consistent with widely used RIXS conventions and with matplotlib scatter and pcolor functions. 