### PR TITLE
Binning changes

### DIFF
--- a/rixs/process2d.py
+++ b/rixs/process2d.py
@@ -282,3 +282,27 @@ def image_to_photon_events(image, min_threshold=-np.inf, max_threshold=np.inf):
                                      image[choose].ravel()))
 
     return photon_events
+
+
+def step_to_bins(y_min, y_max, step):
+    """
+    Construct bins based on a defined step.
+
+    Parameters
+    ----------
+    y_min : float
+        start point of bins range. (modified to )
+    y_max : float
+        end point of bins range
+
+    Returns
+    --------
+    bins : array
+        bin edges for binning on with steps of step
+        and start/end points defined to avoid partially
+        filled bins
+    """
+    start = step*(y_min/step)//1 + step/2
+    stop = step*(y_max/step)//1 - step/2
+    bins = np.arange(start, stop, step)
+    return bins

--- a/rixs/process2d.py
+++ b/rixs/process2d.py
@@ -249,7 +249,8 @@ def photon_events_to_image(photon_events, bins=None):
     return x_centers, y_centers, image, x_edges, y_edges
 
 
-def image_to_photon_events(image, min_threshold=-np.inf, max_threshold=np.inf):
+def image_to_photon_events(image, x_centers=None, y_centers=None,
+                           min_threshold=-np.inf, max_threshold=np.inf):
     """ Convert 2D image into 1D photon events
     This assumes integers define the centers of bins.
     Zeros are not included.
@@ -258,6 +259,12 @@ def image_to_photon_events(image, min_threshold=-np.inf, max_threshold=np.inf):
     -----------
     image : 2D np.array
         photon intensities
+    x_centers : 1D array
+        array of horizontal pixel indices
+        If None this is assumed to start at 0 in 1 unit steps
+    y_centers : 1D array
+        array of vertical pixel indices
+        If None this is assumed to start at 0 in 1 unit steps
     min_threshold : float
         fliter events below this threshold
         defaults to -infinity to include all events
@@ -270,8 +277,10 @@ def image_to_photon_events(image, min_threshold=-np.inf, max_threshold=np.inf):
     photon_events : np.array
         three column x, y, Iph photon locations and intensities
     """
-    x_centers = np.arange(image.shape[1])
-    y_centers = np.arange(image.shape[0])
+    if x_centers is None:
+        x_centers = np.arange(image.shape[1])
+    if y_centers is None:
+        y_centers = np.arange(image.shape[0])
     X_CENTERS, Y_CENTERS = np.meshgrid(x_centers, y_centers)
 
     choose = np.logical_and(image > min_threshold,

--- a/rixs/process2d.py
+++ b/rixs/process2d.py
@@ -303,18 +303,19 @@ def step_to_bins(y_min, y_max, step):
     Parameters
     ----------
     y_min : float
-        start point of bins range. (modified to )
+        start point of bins range.
     y_max : float
-        end point of bins range
+        end point of bins range.
+        step.
 
     Returns
     --------
     bins : array
         bin edges for binning on with steps of step
         and start/end points defined to avoid partially
-        filled bins
+        filled bins and make bin centers rational numbers.
     """
-    start = step*(y_min/step)//1 + step/2
-    stop = step*(y_max/step)//1 - step/2
+    start = step*(((y_min + step/2)/step)//1) + step/2
+    stop = step*(((y_max - step/2)/step)//1 + 1) + step/2
     bins = np.arange(start, stop, step)
     return bins

--- a/rixs/tests/test_process2d.py
+++ b/rixs/tests/test_process2d.py
@@ -51,19 +51,21 @@ def test_curvature_fit():
 
 def test_apply_curvature():
     """Test apply_curvature on simulated data."""
-    y_edges = np.arange(-0.5, 100.5, 1)
-    y_centers = (y_edges[:-1] + y_edges[1:])/2
-    x_centers = 100*rand(y_centers.size)
+    for y_edges in [np.arange(-0.5, 100.5, 1),
+                    np.arange(-7.5, 76.5, 2),
+                    np.arange(-2, 50.3, 0.2)]:
+        y_centers = (y_edges[:-1] + y_edges[1:])/2
+        x_centers = 100*rand(y_centers.size)
 
-    Iph = np.exp(-(y_centers-50)**2)
+        Iph = np.exp(-(y_centers-50)**2)
 
-    photon_events = np.vstack((x_centers, y_centers, Iph)).transpose()
-    spectrum = process2d.apply_curvature(photon_events,
-                                         curvature=np.array([0., 0., 0.]),
-                                         bins=y_edges)
+        photon_events = np.vstack((x_centers, y_centers, Iph)).transpose()
+        spectrum = process2d.apply_curvature(photon_events,
+                                             curvature=np.array([0., 0., 0.]),
+                                             bins=y_edges)
 
-    assert_array_almost_equal(y_centers, spectrum[:, 0])
-    assert_array_almost_equal(Iph, spectrum[:, 1])
+        assert_array_almost_equal(y_centers, spectrum[:, 0])
+        assert_array_almost_equal(Iph, spectrum[:, 1])
 
 
 def test_photon_events_to_image():
@@ -106,3 +108,9 @@ def test_estimate_elastic_pos():
 
     elastic_est = process2d.estimate_elastic_pos(photon_events)
     assert_array_almost_equal(y[elastic_ind], elastic_est)
+
+
+def test_step_to_bins():
+    """Test steps_to_bins"""
+    assert_array_almost_equal(process2d.step_to_bins(-1.1, 3, 0.5),
+                              np.arange(-0.75, 2.75000001, 0.5))


### PR DESCRIPTION
These updates relate to PR #48 on sixtools. This implemented a change to the default binning and allows the code to keep track of the binning even if one wants to crop images with a ROI. This is helpful because it allows sixtools to return directly comparable data from either images or centroided data. 